### PR TITLE
Price range filter feature

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,7 @@ class PagesController < ApplicationController
 
   def home
     @q = Product.ransack(params[:q])
-    @products = @q.result.includes(:category).includes(:brand).order('created_at DESC')
+    @products = @q.result.includes(:category, :brand).order('created_at DESC')
     render :home, locals: { products: @products }
   end
 end

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -8,5 +8,15 @@
     <%= f.label :brand_brand_name_eq, "Brand:" %>
     <%= f.collection_select :brand_brand_name_eq, Brand.all, :brand_name, :brand_name, { include_blank: true }, { class: "form-control w-75" } %>
   </div>
+  <div class="form-row" >
+    <div class="form-group col-md-6">
+      <%= f.label :price_gteq, "Price from" %>
+      <%= f.number_field :price_gteq, class: "form-control w-100" %>
+    </div>
+    <div class="form-group col-md-6">
+      <%= f.label :price_lteq, "Price to" %>
+      <%= f.number_field :price_lteq, class: "form-control w-100" %>
+    </div>
+  </div>
   <%= f.submit "Filter", class: "btn btn-primary w-50" %>
 <% end %>

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :product do
     sequence(:name) { |n| "Product no. #{n}" }
-    price { '9.99' }
+    sequence(:price) { |n| n + 10 }
     association :category
     association :brand
   end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -4,15 +4,26 @@ require 'rails_helper'
 
 RSpec.describe 'Pages', type: :request do
   describe 'GET /' do
-    subject(:request) { get '/' }
-    create_list(:product, 4)
+    subject(:request) { get '/', params: params }
 
-    it 'have ok http status' do
-      expect(request).to have_http_status(:ok)
-    end
+    let(:params) { {} }
+    let(:product) { create(:product) }
+    let(:product2) { create(:product) }
+    let(:product3) { create(:product) }
 
-    it 'have product description' do
-      expect(response.body).to include('This is a place for product description')
+    context 'with filter params provided' do
+      let(:params) { { q: { price_gteq: product.price, price_lteq: product2.price } } }
+
+      it 'have ok http status' do
+        request
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'filter products that belongs only to provided price range' do
+        request
+        expect(response.body).to include(product.name, product2.name)
+        expect(response.body).not_to include(product3.name)
+      end
     end
   end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Pages', type: :request do
+  describe 'GET /' do
+    subject(:request) { get '/' }
+    create_list(:product, 4)
+
+    it 'have ok http status' do
+      expect(request).to have_http_status(:ok)
+    end
+
+    it 'have product description' do
+      expect(response.body).to include('This is a place for product description')
+    end
+  end
+end

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe 'Filters', type: :system do
   end
 
   describe 'when user is selecting category and brand' do
-
     it 'see only products that belongs to selected category and brand' do
       visit_path
       select category.name.to_s, from: 'q_category_name_eq'
@@ -66,7 +65,7 @@ RSpec.describe 'Filters', type: :system do
       expect(page).not_to have_text(product2.name)
     end
   end
-  
+
   describe 'when user is providing price range filter' do
     it 'see only products from provided price range' do
       visit_path

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -69,7 +69,12 @@ RSpec.describe 'Filters', type: :system do
   
   describe 'when user is providing price range filter' do
     it 'see only products from provided price range' do
-      visitin
-    end 
+      visit_path
+      fill_in 'q_price_gteq', with: product.price
+      fill_in 'q_price_lteq', with: product2.price - 1
+      click_button 'Filter'
+      expect(page).to have_text(product.name)
+      expect(page).not_to have_text(product2.name)
+    end
   end
 end

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Filters', type: :system do
+  subject(:visit_path) { visit root_path }
+
   let!(:category) { create(:category) }
   let!(:category2) { create(:category) }
   let!(:brand) { create(:brand) }
@@ -16,14 +18,14 @@ RSpec.describe 'Filters', type: :system do
 
   describe 'when user is selecting category' do
     it 'see only products from selected category' do
-      visit root_path
+      visit_path
       select category.name.to_s, from: 'q_category_name_eq'
       click_button 'Filter'
       expect(page).to have_text(product.name)
     end
 
     it 'doesnt see products from other categories' do
-      visit root_path
+      visit_path
       select category.name.to_s, from: 'q_category_name_eq'
       click_button 'Filter'
       expect(page).not_to have_text(product2.name)
@@ -32,14 +34,14 @@ RSpec.describe 'Filters', type: :system do
 
   describe 'when user is selecting brand' do
     it 'see only products from selected brand' do
-      visit root_path
+      visit_path
       select brand.brand_name.to_s, from: 'q_brand_brand_name_eq'
       click_button 'Filter'
       expect(page).to have_text(product.name)
     end
 
     it 'doesnt see products from other brands' do
-      visit root_path
+      visit_path
       select brand.brand_name.to_s, from: 'q_brand_brand_name_eq'
       click_button 'Filter'
       expect(page).not_to have_text(product2.name)
@@ -47,8 +49,9 @@ RSpec.describe 'Filters', type: :system do
   end
 
   describe 'when user is selecting category and brand' do
+
     it 'see only products that belongs to selected category and brand' do
-      visit root_path
+      visit_path
       select category.name.to_s, from: 'q_category_name_eq'
       select brand.brand_name.to_s, from: 'q_brand_brand_name_eq'
       click_button 'Filter'
@@ -56,11 +59,17 @@ RSpec.describe 'Filters', type: :system do
     end
 
     it 'doesnt see products that belongs to other category or brand' do
-      visit root_path
+      visit_path
       select category.name.to_s, from: 'q_category_name_eq'
       select brand.brand_name.to_s, from: 'q_brand_brand_name_eq'
       click_button 'Filter'
       expect(page).not_to have_text(product2.name)
     end
+  end
+  
+  describe 'when user is providing price range filter' do
+    it 'see only products from provided price range' do
+      visitin
+    end 
   end
 end


### PR DESCRIPTION
### As a shopper, I would like to choose the price range of filtered items, so I can narrow down the number of items I am browsing.
- [x] After filtering by brand or category, a shopper sees a list with predefined price ranges (e.g., "Under $10.00", "$10.00-$15.00", "$15.00-$20.00", "$20.00 or over")
- [x] A shopper can choose one or more price ranges
- [x] After confirming the search, a shopper can see only products within one of the chosen price ranges
- [x] There is a system & request spec

### Requirements for acceptance criteria has been changed during pair programming session. New acceptance criteria:

- [x] A shopper can filter products with minimum and maximum price range 